### PR TITLE
Use 20 nodejs version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,6 @@ inputs:
     description: 'Cloud API endpoint'
     default: 'cr.yandex'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: yc-actions/yc-cr-login@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
